### PR TITLE
build/Node.jsのversion指定対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
-FROM node
+FROM node:22
+
+RUN yarn global add firebase-tools


### PR DESCRIPTION
## 概要
firebase-toolsのインストールに対応するため、
DockerfileのNode.jsバージョンを22に固定した修正のPR。

 - `docker compose build --no-cache`実行時にエラー発生、そのエラー解消に対応するための修正
 - エラー内容詳細は #12 を参照

## 手順
1. Node.js 22のDockerイメージを利用
2. Dockerfileを修正し、firebase-toolsをグローバルインストール
3. docker compose build --no-cache でビルドし、エラーが解消されることを確認

## 変更点
 -  Dockerfile
   - DockerfileのNode.jsバージョンを22に固定
　　 -  https://github.com/maixhashi/my-tech-blog/blob/ee6bb8bb5fae4d08074ba66e0a0aa9d654bac114/Dockerfile#L1-L1


## 補足・参考リンク
- [GitHub - firebase/firebase-tools](https://github.com/firebase/firebase-tools)
- [GitHub - firebase/superstatic](https://github.com/firebase/superstatic/issues) 

## 関連
close #12