### PR TITLE
build/.dockerignoreの設定

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+README.md
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.next
+out
+.DS_Store
+*.tgz
+*.tar.gz 


### PR DESCRIPTION
## 概要
Dockerイメージビルド時に不要なファイルを除外するため、`.dockerignore` を設定。

## 変更内容
- `.dockerignore` を新規作成し、不要ファイル・ディレクトリを除外設定

## 追加されたファイル
- `.dockerignore`: Dockerビルド時に除外するファイル・ディレクトリを指定

## 変更されたファイル

### .dockerignore

#### node_modules

https://github.com/maixhashi/my-tech-blog/blob/a54437e35e902bedf9ce1980999e6e4345f5aadd/.dockerignore#L1-L1
→ ローカルの依存パッケージはコンテナ内で再インストールするため、コピー不要。

#### .git, .gitignore, README.md

https://github.com/maixhashi/my-tech-blog/blob/a54437e35e902bedf9ce1980999e6e4345f5aadd/.dockerignore#L3-L5
→ ソース管理やドキュメントは本番イメージには不要。

#### .env*

https://github.com/maixhashi/my-tech-blog/blob/a54437e35e902bedf9ce1980999e6e4345f5aadd/.dockerignore#L6-L10
→ 環境変数ファイルの漏洩防止。

#### .next, out

https://github.com/maixhashi/my-tech-blog/blob/a54437e35e902bedf9ce1980999e6e4345f5aadd/.dockerignore#L11-L12
→ Next.js のビルド成果物は通常ビルド時に生成するので、ローカルのものは不要。

#### *.tgz, *.tar.gz, .DS_Store

https://github.com/maixhashi/my-tech-blog/blob/a54437e35e902bedf9ce1980999e6e4345f5aadd/.dockerignore#L13-L15
→ 一時ファイルやOS依存の不要ファイル。

---

### まとめ
`.dockerignore` を使うことで、
- Docker イメージのサイズを小さくできる
- ビルドが速くなる
- セキュリティリスク（不要なファイルの混入や漏洩）を減らせる

## テスト
- Dockerイメージビルド時に不要ファイルが含まれないことを確認
