### PR TITLE
build/frontend/tailwindcss line-clampのインストール

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "gray-matter": "^4.0.3",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/line-clamp')],
 };
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,6 +248,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/line-clamp@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz#767cf8e5d528a5d90c9740ca66eb079f5e87d423"
+  integrity sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"


### PR DESCRIPTION
## 概要
Tailwind CSSのline-clampプラグインを導入し、記事タイトル等のテキストの省略表示できるようにする。

## 変更内容
- tailwindcss-line-clampのインストール
- tailwind.config.tsへのプラグイン追加

## 変更ファイル
 - `yarn add @tailwindcss/line-clamp` による出力
   - package.json
   - yarn.lock 
- tailwind.config.ts: line-clampプラグインの追加


## 詳細

### package.json
https://github.com/maixhashi/my-tech-blog/blob/584da2fde880892aa846b4076aaf03763e1984dc/package.json#L9

### yarn.lock
https://github.com/maixhashi/my-tech-blog/blob/584da2fde880892aa846b4076aaf03763e1984dc/yarn.lock#L251-L254

### tailwind.config.ts
https://github.com/maixhashi/my-tech-blog/blob/584da2fde880892aa846b4076aaf03763e1984dc/tailwind.config.ts#L42


## 参考
 - [Tailwind CSS公式 - Line Clamp](https://tailwindcss.com/docs/line-clamp)