### PR TITLE
feature/frontend/レスポンシブデザインのbreakpoint画面幅を定義

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,20 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        'xs': '390px',
+        'sm': '768px',
+        'md': '1024px',
+        'lg': '1440px',
+        'xl': '1920px',
+      },
+      maxWidth: {
+        'design-xs': '390px',
+        'design-sm': '768px',
+        'design-md': '1024px',
+        'design-lg': '1440px',
+        'design-xl': '1920px',
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
## 概要
Tailwind CSSの設定ファイル（tailwind.config.ts）に、
プロジェクト要件に合わせた独自のブレークポイント（画面幅）の定義を追加。

## 変更内容
- tailwind.config.ts の `theme.extend.screens` に以下のブレークポイントを新規定義
  - xs: 390px（iPhone mini等）
  - sm: 768px（タブレット縦）
  - md: 1024px（タブレット横）
  - lg: 1440px（PC標準）
  - xl: 1920px（大型ディスプレイ）

## 追加・変更されたファイル
- tailwind.config.ts: ブレークポイント定義の追加

## ファイル詳細

### tailwind.config.ts
https://github.com/maixhashi/my-tech-blog/blob/3c6da354b944f1d8d8c1db80447dcdc205f5ccf4/tailwind.config.ts#L12-L25

## テスト
- ローカル環境で `yarn dev` にてビルド・起動確認
- 各ブレークポイント幅でのスタイル適用確認

## 関連Issue
- close #23

## 補足
- Figma等のデザイン仕様に合わせて今後もブレークポイントを調整する可能性あり
