### PR TITLE
build/frontend/tailwindcss line-clampプラグインの削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tailwindcss/line-clamp": "^0.4.4",
     "classnames": "^2.5.1",
     "date-fns": "^3.6.0",
     "gray-matter": "^4.0.3",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require('@tailwindcss/line-clamp')],
+  plugins: [],
 };
 export default config;


### PR DESCRIPTION
## 概要
Next.js 15でデフォルトでline-clamp機能が含まれるため、`@tailwindcss/line-clamp`プラグインを削除。

## 変更内容
- `@tailwindcss/line-clamp`パッケージを依存関係から削除
- `tailwind.config.ts`からline-clampプラグインの設定を削除

## 追加されたファイル
- なし

## 変更されたファイル

### package.json
`@tailwindcss/line-clamp`パッケージを依存関係から削除

### tailwind.config.ts
line-clampプラグインの設定を削除し、空のplugins配列に変更

## テスト
- ローカル環境でのビルド確認
- line-clamp機能が正常に動作することを確認
- 既存のスタイリングに影響がないことを確認

## 関連Issue
- ref #21